### PR TITLE
Relative path for bitmaps and masks

### DIFF
--- a/Tractor/Com.QuantAsylum.Tractor.Tests/GainLevel/FreqResponseA01.cs
+++ b/Tractor/Com.QuantAsylum.Tractor.Tests/GainLevel/FreqResponseA01.cs
@@ -1,5 +1,6 @@
 ﻿using Com.QuantAsylum.Tractor.TestManagers;
 using System;
+using System.IO;
 using Tractor.Com.QuantAsylum.Tractor.Tests;
 
 namespace Com.QuantAsylum.Tractor.Tests.GainTests
@@ -35,13 +36,17 @@ namespace Com.QuantAsylum.Tractor.Tests.GainTests
             // Two channels
             tr = new TestResult(2);
 
+            // Get the absolute path of the mask file
+            string appDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            string absolutePath = Path.Combine(appDirectory, MaskFileName);
+
             Tm.SetToDefaults();
             SetupBaseTests();
 
             ((IAudioAnalyzer)Tm.TestClass).AudioAnalyzerSetTitle(title);
             ((IAudioAnalyzer)Tm.TestClass).SetInputRange(AnalyzerInputRange.InputRange);
             ((IAudioAnalyzer)Tm.TestClass).DoFrAquisition(AnalyzerOutputLevel, 0, SmoothingDenominator);
-            ((IAudioAnalyzer)Tm.TestClass).TestMask(MaskFileName, LeftChannel, RightChannel, false, out bool passLeft, out bool passRight, out _);
+            ((IAudioAnalyzer)Tm.TestClass).TestMask(absolutePath, LeftChannel, RightChannel, false, out bool passLeft, out bool passRight, out _);
 
             TestResultBitmap = ((IAudioAnalyzer)Tm.TestClass).GetBitmap();
 

--- a/Tractor/Com.QuantAsylum.Tractor.Tests/GainLevel/FreqResponseA03.cs
+++ b/Tractor/Com.QuantAsylum.Tractor.Tests/GainLevel/FreqResponseA03.cs
@@ -1,5 +1,6 @@
 ﻿using Com.QuantAsylum.Tractor.TestManagers;
 using System;
+using System.IO;
 using Tractor.Com.QuantAsylum.Tractor.Tests;
 
 namespace Com.QuantAsylum.Tractor.Tests.GainTests
@@ -37,6 +38,10 @@ namespace Com.QuantAsylum.Tractor.Tests.GainTests
             // Two channels
             tr = new TestResult(2);
 
+            // Get the absolute path of the mask file
+            string appDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            string absolutePath = Path.Combine(appDirectory, MaskFileName);
+
             Tm.SetToDefaults();
             SetupBaseTests();
 
@@ -45,7 +50,7 @@ namespace Com.QuantAsylum.Tractor.Tests.GainTests
             ((IAudioAnalyzer)Tm.TestClass).AudioAnalyzerSetTitle(title);
             ((IAudioAnalyzer)Tm.TestClass).SetInputRange(AnalyzerInputRange.InputRange);
             ((IAudioAnalyzer)Tm.TestClass).DoFrAquisition(AnalyzerOutputLevel, 0, SmoothingDenominator);
-            ((IAudioAnalyzer)Tm.TestClass).TestMask(MaskFileName, LeftChannel, RightChannel, false, out bool passLeft, out bool passRight, out _);
+            ((IAudioAnalyzer)Tm.TestClass).TestMask(absolutePath, LeftChannel, RightChannel, false, out bool passLeft, out bool passRight, out _);
 
             TestResultBitmap = ((IAudioAnalyzer)Tm.TestClass).GetBitmap();
 

--- a/Tractor/Com.QuantAsylum.Tractor.Tests/Operator/PromptA00.cs
+++ b/Tractor/Com.QuantAsylum.Tractor.Tests/Operator/PromptA00.cs
@@ -1,6 +1,7 @@
 ﻿using Com.QuantAsylum.Tractor.Dialogs;
 using System;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 using Tractor;
 using Tractor.Com.QuantAsylum.Tractor.Tests;
@@ -38,7 +39,11 @@ namespace Com.QuantAsylum.Tractor.Tests
             {
                 if (BitmapFile.Trim() != "")
                 {
-                    bmp = new Bitmap(BitmapFile);
+                    // Get the absolute path of the bitmap file
+                    string appDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                    string absolutePath = Path.Combine(appDirectory, BitmapFile);
+
+                    bmp = new Bitmap(absolutePath);
                 }
             }
             catch (Exception ex)

--- a/Tractor/Com.QuantAsylum.Tractor.Tests/Other/MicCompareA01.cs
+++ b/Tractor/Com.QuantAsylum.Tractor.Tests/Other/MicCompareA01.cs
@@ -1,5 +1,6 @@
 ﻿using Com.QuantAsylum.Tractor.TestManagers;
 using System;
+using System.IO;
 using Tractor.Com.QuantAsylum.Tractor.Tests;
 
 namespace Com.QuantAsylum.Tractor.Tests.GainTests
@@ -43,11 +44,16 @@ namespace Com.QuantAsylum.Tractor.Tests.GainTests
             Tm.SetToDefaults();
             SetupBaseTests();
 
+            // Get the absolute path of the mask file
+            string appDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            string absolutePath = Path.Combine(appDirectory, MaskFileName);
+
+
             ((IAudioAnalyzer)Tm.TestClass).AudioAnalyzerSetTitle(title);
             ((IAudioAnalyzer)Tm.TestClass).SetInputRange(AnalyzerInputRange.InputRange);
 
             ((IAudioAnalyzer)Tm.TestClass).DoFrAquisition(AnalyzerOutputLevel, WindowingMs/1000, SmoothingDenominator);
-            ((IAudioAnalyzer)Tm.TestClass).TestMask(MaskFileName, false, false, true, out bool passLeft, out bool passRight, out bool passMath);
+            ((IAudioAnalyzer)Tm.TestClass).TestMask(absolutePath, false, false, true, out bool passLeft, out bool passRight, out bool passMath);
             ((IAudioAnalyzer)Tm.TestClass).AddMathToDisplay();
 
             TestResultBitmap = ((IAudioAnalyzer)Tm.TestClass).GetBitmap();

--- a/Tractor/Form1.cs
+++ b/Tractor/Form1.cs
@@ -59,6 +59,37 @@ namespace Tractor
             Tm = new TestManager();
             Type t = Type.GetType(AppSettings.TestClass);
             Tm.TestClass = Activator.CreateInstance(t);
+
+            // Enable drag and drop for this form
+            this.AllowDrop = true;
+
+            // Add event handlers for the DragEnter and DragDrop events
+            this.DragEnter += new DragEventHandler(Form1_DragEnter);
+            this.DragDrop += new DragEventHandler(Form1_DragDrop);
+        }
+
+        private void Form1_DragEnter(object sender, DragEventArgs e)
+        {
+            // Check if the data being dragged is a file
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+                e.Effect = DragDropEffects.Copy; // Show the copy cursor
+            else
+                e.Effect = DragDropEffects.None; // Show the no-drop cursor
+        }
+
+        private void Form1_DragDrop(object sender, DragEventArgs e)
+        {
+            // Get the files being dragged
+            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+
+            // Load the first file in the list (if any)
+            if (files.Length > 0)
+            {
+                string filePath = files[0];
+                // Load your test plan from the file path
+                LoadFromFile(filePath);
+
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Added relative path capabilities for both bitmap and masks. This is relative to the application base path. 

Also added drag+drop test plan load capability. Just drag test file onto tractor app to open test plan. 