### PR TITLE
KL8 MIDI test update

### DIFF
--- a/Tractor/Com.QuantAsylum.Tractor.Tests/Other/KL8MIDI.cs
+++ b/Tractor/Com.QuantAsylum.Tractor.Tests/Other/KL8MIDI.cs
@@ -1,0 +1,130 @@
+﻿using Com.QuantAsylum.Tractor.TestManagers;
+using System;
+using Tractor.Com.QuantAsylum.Tractor.Tests;
+using System.IO.Ports;
+using System.Threading;
+using NAudio.Midi;
+
+
+namespace Com.QuantAsylum.Tractor.Tests
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    [Serializable]
+    public class KL8MIDI : MIDITestBase
+    {
+        [ObjectEditorAttribute(Index = 200, DisplayText = "MIDI Input Device Name", MaxLength = 512)]
+        public string inDevName = "";
+
+        [ObjectEditorAttribute(Index = 200, DisplayText = "MIDI Output Device Name", MaxLength = 512)]
+        public string outDevName = "";
+
+        private readonly ManualResetEvent _echoReceivedEvent = new ManualResetEvent(false);
+        private int[] _receivedData = new int[2];
+
+        const int noteNumber = 60; // Middle C
+        const int velocity = 100; // Velocity value (0-127)
+
+        public KL8MIDI() : base()
+        {
+            Name = this.GetType().Name;
+            _TestType = TestTypeEnum.Other;
+        }
+
+        public override void DoTest(string title, out TestResult tr)
+        {
+            tr = new TestResult(2);
+            bool pass = false;
+
+            // Find output device
+            int outDeviceIndex = -1;
+            for (int i = 0; i < MidiOut.NumberOfDevices; i++)
+            {
+                var info = MidiOut.DeviceInfo(i);
+                if (info.ProductName != null && info.ProductName.Contains(outDevName))
+                {
+                    outDeviceIndex = i;
+                    break;
+                }
+            }
+           
+            if (outDeviceIndex == -1)
+            {
+                tr.StringValue[0] = "Requested MIDI output device not found."; 
+                tr.Pass = false;
+                return;
+            }
+
+            // Find input deviceq
+            int inDeviceIndex = -1;
+            for (int i = 0; i < MidiIn.NumberOfDevices; i++)
+            {
+                var info = MidiIn.DeviceInfo(i);
+                if (info.ProductName != null && info.ProductName.Contains(inDevName))
+                {
+                    inDeviceIndex = i;
+                    break;
+                }
+            }
+
+            if (inDeviceIndex == -1)
+            {
+                tr.StringValue[0] = "Requested MIDI input device not found.";
+                tr.Pass = false;
+                return;
+            }
+
+            // Create a new MIDI input device
+            using (var midiOut = new MidiOut(outDeviceIndex))
+            using (var midiIn = new MidiIn(inDeviceIndex))
+            {
+                midiIn.MessageReceived += (sender, e) =>
+                {
+                    // Handle incoming MIDI messages here
+                    var message = e.MidiEvent;
+                    if (message.CommandCode == MidiCommandCode.NoteOn)
+                    {
+                        // Process Note On message
+                        var noteOnMessage = (NoteOnEvent)message;
+                        _receivedData[0] = noteOnMessage.NoteNumber;
+                        _receivedData[1] = noteOnMessage.Velocity;
+                        _echoReceivedEvent.Set();
+                    }
+                };
+                midiIn.Start();
+
+                // Send a MIDI message to the output device
+                var noteOn = new NoteOnEvent(0, 1, noteNumber, velocity, 0);
+                midiOut.Send(noteOn.GetAsShortMessage());
+                tr.StringValue[0] = "MIDI Sent";
+
+                // Wait for the echo received event
+                if (!_echoReceivedEvent.WaitOne(5000))
+                {
+                    tr.StringValue[1] = "No response from device";
+                    tr.Pass = false;
+                    return;
+                }
+                // Check if the received data matches the expected data
+                if ((_receivedData[0] == noteNumber) && (_receivedData[1] == velocity))
+                {
+                    //Console.WriteLine("Echo received: " + _receivedData);
+                    _echoReceivedEvent.Reset();
+                    tr.StringValue[1] = "MIDI Received";
+                    pass = true;
+                }
+
+            }
+            
+
+            tr.Pass = pass;
+
+        }
+   
+        public override string GetTestDescription()
+        {
+            return "Opens a user specified MIDI input and output device, sends test data from MIDI out and verifies the same data at the MIDI input device.)";
+        }
+    }
+}

--- a/Tractor/Com.QuantAsylum.Tractor.Tests/TestBase.cs
+++ b/Tractor/Com.QuantAsylum.Tractor.Tests/TestBase.cs
@@ -94,6 +94,7 @@ namespace Com.QuantAsylum.Tractor.Tests
     [System.Xml.Serialization.XmlInclude(typeof(LRBalanceA01))]
     [System.Xml.Serialization.XmlInclude(typeof(PhaseTest180A01))]
     [System.Xml.Serialization.XmlInclude(typeof(GainLRLimitsA01))]
+    [System.Xml.Serialization.XmlInclude(typeof(KL8MIDI))]
 
     //
     // Naming Convention for classes:
@@ -247,6 +248,11 @@ namespace Com.QuantAsylum.Tractor.Tests
     }
 
     public class PhaseTestBase : TestBase
+    {
+
+    }
+
+    public class MIDITestBase : TestBase
     {
 
     }

--- a/Tractor/QA Tractor.csproj
+++ b/Tractor/QA Tractor.csproj
@@ -54,6 +54,15 @@
     <ApplicationIcon>Tractor Icon2.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NAudio.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
+      <HintPath>packages\NAudio.Core.2.2.1\lib\netstandard2.0\NAudio.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NAudio.Midi, Version=2.2.1.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
+      <HintPath>packages\NAudio.Midi.2.2.1\lib\netstandard2.0\NAudio.Midi.dll</HintPath>
+    </Reference>
+    <Reference Include="NAudio.Wasapi, Version=2.2.1.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
+      <HintPath>packages\NAudio.Wasapi.2.2.1\lib\netstandard2.0\NAudio.Wasapi.dll</HintPath>
+    </Reference>
     <Reference Include="QAAnalyzer, Version=1.9.0.7, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\QuantAsylum\QA401\QAAnalyzer.exe</HintPath>
@@ -178,6 +187,7 @@
     <Compile Include="Com.QuantAsylum.Tractor.Tests\Other\MicCompareA01.cs" />
     <Compile Include="Com.QuantAsylum.Tractor.Tests\Other\MidiSendXL.cs" />
     <Compile Include="Com.QuantAsylum.Tractor.Tests\Other\PhaseTest180A01.cs" />
+    <Compile Include="Com.QuantAsylum.Tractor.Tests\Other\KL8MIDI.cs" />
     <Compile Include="Com.QuantAsylum.Tractor.Tests\Other\SerialSendXL.cs" />
     <Compile Include="Com.QuantAsylum.Tractor.Tests\Other\PhaseA03.cs" />
     <Compile Include="Com.QuantAsylum.Tractor.Tests\Other\PhaseA01.cs" />

--- a/Tractor/packages.config
+++ b/Tractor/packages.config
@@ -1,4 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="NAudio.Core" version="2.2.1" targetFramework="net48" />
+  <package id="NAudio.Midi" version="2.2.1" targetFramework="net48" />
+  <package id="NAudio.Wasapi" version="2.2.1" targetFramework="net48" />
   <package id="ZedGraph" version="5.1.7" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
This test opens a user defined MIDI input and output device connected in loopback, and sends and verifies a test MIDI note data for PASS/FAIL. 

Closes #23 