### PR TITLE
33 feature add output mirroring

### DIFF
--- a/Tractor/Com.QuantAsylum.Hardware/QA351.cs
+++ b/Tractor/Com.QuantAsylum.Hardware/QA351.cs
@@ -78,6 +78,11 @@ namespace Tractor.Com.QuantAsylum.Hardware
 
         }
 
+        public bool SetToDefaults(string title)
+        {
+            return true;
+        }
+
         public float GetVoltage(int channel)
         {
             if (channel < 0 || channel > 1)

--- a/Tractor/Com.QuantAsylum.Hardware/QA401.cs
+++ b/Tractor/Com.QuantAsylum.Hardware/QA401.cs
@@ -42,6 +42,11 @@ namespace Com.QuantAsylum.Hardware
             Qa401.SetToDefault("");
         }
 
+        public bool SetToDefaults(string title)
+        {
+            return Qa401.SetToDefault(title);
+        }
+
         public double GetVersion()
         {
             return Qa401.GetVersion();

--- a/Tractor/Com.QuantAsylum.Hardware/QA401H.cs
+++ b/Tractor/Com.QuantAsylum.Hardware/QA401H.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web.Script.Serialization;
+using Tractor.Com.QuantAsylum.Hardware;
 
 namespace Com.QuantAsylum.Hardware
 {
@@ -51,8 +52,13 @@ namespace Com.QuantAsylum.Hardware
             return 0;
         }
 
+        public bool SetToDefaults(string title)
+        {
+            return true;
+        }
 
-            public void AudioAnalyzerSetTitle(string s)
+
+        public void AudioAnalyzerSetTitle(string s)
         {
             return;
         }

--- a/Tractor/Com.QuantAsylum.Hardware/QA401_QA351.cs
+++ b/Tractor/Com.QuantAsylum.Hardware/QA401_QA351.cs
@@ -166,6 +166,10 @@ namespace Com.QuantAsylum.Hardware
             Qa401.SetToDefaults();
             Qa351.SetToDefaults();
         }
+        public bool SetToDefaults(string title)
+        {
+            return true;
+        }
 
         public bool IsConnected()
         {

--- a/Tractor/Com.QuantAsylum.Hardware/QA401_QA450.cs
+++ b/Tractor/Com.QuantAsylum.Hardware/QA401_QA450.cs
@@ -234,6 +234,11 @@ namespace Com.QuantAsylum.Hardware
             Qa450.SetToDefaults();
         }
 
+        public bool SetToDefaults(string title)
+        {
+            return true;
+        }
+
         public bool IsConnected()
         {
             if (Qa401.IsConnected() && Qa450.IsConnected())

--- a/Tractor/Com.QuantAsylum.Hardware/QA40x.cs
+++ b/Tractor/Com.QuantAsylum.Hardware/QA40x.cs
@@ -135,6 +135,11 @@ namespace Com.QuantAsylum.Hardware
 
         }
 
+        public bool SetToDefaults(string title)
+        {
+            return true;
+        }
+
         public Bitmap GetBitmap()
         {
             WebClient client = new WebClient();

--- a/Tractor/Com.QuantAsylum.Hardware/QA450.cs
+++ b/Tractor/Com.QuantAsylum.Hardware/QA450.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Web.Script.Serialization;
+using Tractor.Com.QuantAsylum.Hardware;
 
 namespace Com.QuantAsylum.Hardware
 {
@@ -27,6 +28,11 @@ namespace Com.QuantAsylum.Hardware
             {
                 BaseAddress = new Uri(RootUrl)
             };
+        }
+
+        public bool SetToDefaults(string title)
+        {
+            return true;
         }
 
         public bool ConnectToDevice(out string result)

--- a/Tractor/Com.QuantAsylum.Tractor.TestManagers/IInstrument.cs
+++ b/Tractor/Com.QuantAsylum.Tractor.TestManagers/IInstrument.cs
@@ -12,6 +12,7 @@ namespace Com.QuantAsylum.Tractor.TestManagers
     interface IInstrument
     {
         void SetToDefaults();
+        bool SetToDefaults(string fileName);
         bool IsRunning();
         void LaunchApplication();
         bool ConnectToDevice(out string result);

--- a/Tractor/Com.QuantAsylum.Tractor.TestManagers/TestManager.cs
+++ b/Tractor/Com.QuantAsylum.Tractor.TestManagers/TestManager.cs
@@ -43,5 +43,10 @@ namespace Com.QuantAsylum.Tractor.TestManagers
         {
             ((IInstrument)TestClass).SetToDefaults();
         }
+
+        public bool SetToDefaults(string fileName)
+        {
+            return ((IInstrument)TestClass).SetToDefaults(fileName);
+        }
     }
 }

--- a/Tractor/Constants.cs
+++ b/Tractor/Constants.cs
@@ -10,7 +10,7 @@ namespace Tractor
     static class Constants 
     {
         public static string TitleBarText = "QA TRACTOR RadialEng";
-        public static readonly double Version = 1.400;
+        public static readonly double Version = 1.401;
         public static string VersionSuffix = "";
 
         public static double RequiredWebserviceVersion = 0.5;

--- a/Tractor/Constants.cs
+++ b/Tractor/Constants.cs
@@ -30,5 +30,6 @@ namespace Tractor
         static public string LogFile = Path.Combine(DataFilePath, "Tractor_Log.txt");
         static public string TmpLogFile = Path.Combine(DataFilePath, "Tractor_Log_tmp.txt");
         static public string AutoDocFile = Path.Combine(DataFilePath, "Tractor_Help.md");
+        static public string QA401Path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "QuantAsylum", "QA401");
     }
 }


### PR DESCRIPTION
closes #33 

Needed to have output mirroring engaged but each test gets set to default settings every time. I changed the GainA01 test so that a settings file can be applied before the test. Will use default settings when the textbox is empty, otherwise it will look for the settings file in the same directory as the Tractor executable. 
To get this to work, the settings file is copied from the Tractor executable directory to the QA401 directory. 